### PR TITLE
Feat/creat kpt

### DIFF
--- a/backend/.annotaterb.yml
+++ b/backend/.annotaterb.yml
@@ -1,0 +1,58 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: false
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -319,6 +319,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 7.1.5, >= 7.1.5.1)
+  rails-i18n (~> 7.0.0)
   rspec-rails
   rubocop
   rubocop-faker

--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -2,5 +2,4 @@ class Api::V1::BaseController < ApplicationController
   alias_method :current_user, :current_api_v1_user
   alias_method :authenticate_user!, :authenticate_api_v1_user!
   alias_method :user_signed_in?, :api_v1_user_signed_in?
-
 end

--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::BaseController < ApplicationController
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
+
+end

--- a/backend/app/controllers/api/v1/kpts_controller.rb
+++ b/backend/app/controllers/api/v1/kpts_controller.rb
@@ -2,9 +2,13 @@ class Api::V1::KptsController < Api::V1::BaseController
   before_action :authenticate_user!
 
   def create
-    kpt = current_user.kpts.create!(kpt_params)
-    render json: { message: "Success", kpt: kpt }, status: :created
-    debugger
+    kpt = current_user.kpts.new(kpt_params)
+    if kpt.save
+      render json: { message: "Success", kpt: kpt }, status: :created
+    else
+      debugger
+      render json: { message: kpt.errors.full_messages.to_sentence }, status: :unprocessable
+    end
   end
 
   private

--- a/backend/app/controllers/api/v1/kpts_controller.rb
+++ b/backend/app/controllers/api/v1/kpts_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::KptsController < Api::V1::BaseController
+  before_action :authenticate_user!
+
+  def create
+    kpt = current_user.kpts.create!(kpt_params)
+    render json: { message: "Success", kpt: kpt }, status: :created
+    debugger
+  end
+
+  private
+  def kpt_params
+    params.require(:kpt).permit(:date, :keep, :problem, :try)
+  end
+end

--- a/backend/app/controllers/api/v1/kpts_controller.rb
+++ b/backend/app/controllers/api/v1/kpts_controller.rb
@@ -6,7 +6,6 @@ class Api::V1::KptsController < Api::V1::BaseController
     if kpt.save
       render json: { message: "Success", kpt: kpt }, status: :created
     else
-      debugger
       render json: { message: kpt.errors.full_messages.to_sentence }, status: :unprocessable
     end
   end

--- a/backend/app/controllers/api/v1/kpts_controller.rb
+++ b/backend/app/controllers/api/v1/kpts_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::KptsController < Api::V1::BaseController
   end
 
   private
-  def kpt_params
-    params.require(:kpt).permit(:date, :keep, :problem, :try)
-  end
+
+    def kpt_params
+      params.require(:kpt).permit(:date, :keep, :problem, :try)
+    end
 end

--- a/backend/app/controllers/api/v1/kpts_controller.rb
+++ b/backend/app/controllers/api/v1/kpts_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::KptsController < Api::V1::BaseController
     if kpt.save
       render json: { message: "Success", kpt: kpt }, status: :created
     else
-      render json: { message: kpt.errors.full_messages.to_sentence }, status: :unprocessable
+      render json: { message: kpt.errors.full_messages.to_sentence }, status: :unprocessable_entity
     end
   end
 

--- a/backend/app/models/kpt.rb
+++ b/backend/app/models/kpt.rb
@@ -21,5 +21,11 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Kpt < ApplicationRecord
+  validates :date, presence: true
+  validates :date, uniqueness: { scope: :user_id, message: "already has a KPT entry for this day" }
+  validates :keep, presence: true
+  validates :problem, presence: true
+  validates :try, presence: true
+
   belongs_to :user
 end

--- a/backend/app/models/kpt.rb
+++ b/backend/app/models/kpt.rb
@@ -22,7 +22,7 @@
 #
 class Kpt < ApplicationRecord
   validates :date, presence: true
-  validates :date, uniqueness: { scope: :user_id, message: "この日のKPTのはすでに登録されています" }
+  validates :date, uniqueness: { scope: :user_id }
   validates :keep, presence: true
   validates :problem, presence: true
   validates :try, presence: true

--- a/backend/app/models/kpt.rb
+++ b/backend/app/models/kpt.rb
@@ -22,7 +22,7 @@
 #
 class Kpt < ApplicationRecord
   validates :date, presence: true
-  validates :date, uniqueness: { scope: :user_id, message: "already has a KPT entry for this day" }
+  validates :date, uniqueness: { scope: :user_id, message: "この日のKPTのはすでに登録されています" }
   validates :keep, presence: true
   validates :problem, presence: true
   validates :try, presence: true

--- a/backend/app/models/kpt.rb
+++ b/backend/app/models/kpt.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: kpts
+#
+#  id         :bigint           not null, primary key
+#  date       :date             not null
+#  keep       :text(65535)
+#  problem    :text(65535)
+#  try        :text(65535)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
+# Indexes
+#
+#  index_kpts_on_user_id           (user_id)
+#  index_kpts_on_user_id_and_date  (user_id,date) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Kpt < ApplicationRecord
+  belongs_to :user
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,9 +1,42 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string(255)
+#  confirmed_at           :datetime
+#  email                  :string(255)
+#  encrypted_password     :string(255)      default(""), not null
+#  image                  :string(255)
+#  name                   :string(255)
+#  nickname               :string(255)
+#  provider               :string(255)      default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string(255)
+#  tokens                 :text(65535)
+#  uid                    :string(255)      default(""), not null
+#  unconfirmed_email      :string(255)
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  has_many :kpts, dependent: :destroy
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -1,0 +1,184 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      password_too_long: が長すぎます
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/backend/config/locales/models.ja.yml
+++ b/backend/config/locales/models.ja.yml
@@ -1,0 +1,17 @@
+ja:
+  activerecord:
+    models:
+      kpt: KPT
+    attributes:
+      kpt:
+        date: 日付
+        keep: Keep
+        problem: Problem
+        try: Try
+        user: ユーザー
+    errors:
+      models:
+        kpt:
+          attributes:
+            date:
+              taken: "この日のKPTはすでに登録されています"

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get "health_check" => "health_check#show"
       mount_devise_token_auth_for "User", at: "auth"
+      resources :kpts, only: %i[create]
     end
   end
 

--- a/backend/db/migrate/20250318011653_create_kpts.rb
+++ b/backend/db/migrate/20250318011653_create_kpts.rb
@@ -1,0 +1,14 @@
+class CreateKpts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :kpts do |t|
+      t.references :user, foreign_key: true
+      t.date :date, null: false
+      t.text :keep
+      t.text :problem
+      t.text :try
+      t.timestamps
+    end
+
+    add_index :kpts, [:user_id, :date], unique: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_250_317_082_554) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_18_011653) do
+  create_table "kpts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.date "date", null: false
+    t.text "keep"
+    t.text "problem"
+    t.text "try"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "date"], name: "index_kpts_on_user_id_and_date", unique: true
+    t.index ["user_id"], name: "index_kpts_on_user_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -35,4 +47,6 @@ ActiveRecord::Schema[7.1].define(version: 20_250_317_082_554) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
+
+  add_foreign_key "kpts", "users"
 end

--- a/backend/lib/tasks/annotate_rb.rake
+++ b/backend/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/backend/spec/factories/kpts.rb
+++ b/backend/spec/factories/kpts.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :kpt do
+    date { Date.current }
+    keep { Faker::Lorem.paragraph(sentence_count: 2) }
+    problem { Faker::Lorem.paragraph(sentence_count: 2) }
+    try { Faker::Lorem.paragraph(sentence_count: 2) }
+    association :user
+  end
+end

--- a/backend/spec/factories/user.rb
+++ b/backend/spec/factories/user.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { Faker::Internet.unique.email }
+    password { "password" }
+  end
+end

--- a/backend/spec/models/kpt_spec.rb
+++ b/backend/spec/models/kpt_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe Kpt, type: :model do
+  context "正しいプロパティを受け取った場合" do
+    let(:kpt) { build(:kpt) }
+
+    it "バリデーションに通過する" do
+      expect(kpt).to be_valid
+    end
+
+    it "正常に保存できる" do
+      expect{kpt.save}.to change(Kpt, :count).by(1)
+    end
+  end
+
+  context "userがnilの場合" do
+    let(:kpt) { build(:kpt, user: nil) }
+  
+    it "バリデーションエラーになる" do
+      expect(kpt).not_to be_valid
+    end
+  
+    it "エラーメッセージが設定される" do
+      kpt.valid?
+      expect(kpt.errors[:user]).to include("を入力してください")
+    end
+  end
+
+  describe "バリデーション" do
+    context "dateがnilの場合" do
+      let(:kpt) { build(:kpt, date: nil) }
+
+      it "バリデーションエラーになる" do
+        expect(kpt).not_to be_valid
+      end
+
+      it "エラーメッセージが設定される" do
+        kpt.valid?
+        expect(kpt.errors[:date]).to include("を入力してください")
+      end
+    end
+
+    context "dateが重複している場合" do
+      let(:user) { create(:user) }
+      let!(:existing_kpt) { create(:kpt, date: Date.today, user: user) }
+      let(:kpt) { build(:kpt, date: Date.today, user: user) }
+
+      it "バリデーションエラーになる" do
+        expect { kpt.save }.not_to change(Kpt, :count)
+      end
+
+      it "エラーメッセージが設定される" do
+        kpt.valid?
+        expect(kpt.errors[:date]).to include("この日のKPTのはすでに登録されています")
+      end
+    end
+  
+    context "keepがnilの場合" do
+      let(:kpt) { build(:kpt, keep: nil) }
+
+      it "バリデーションエラーになる" do
+        expect(kpt).not_to be_valid
+      end
+
+      it "エラーメッセージが設定される" do
+        kpt.valid?
+        expect(kpt.errors[:keep]).to include("を入力してください")
+      end
+    end
+
+    context "problemがnilの場合" do
+      let(:kpt) { build(:kpt, problem: nil) }
+
+      it "バリデーションエラーになる" do
+        expect(kpt).not_to be_valid
+      end
+
+      it "エラーメッセージが設定される" do
+        kpt.valid?
+        expect(kpt.errors[:problem]).to include("を入力してください")
+      end
+    end
+
+    context "tryがnilの場合" do
+      let(:kpt) { build(:kpt, try: nil) }
+
+      it "バリデーションエラーになる" do
+        expect(kpt).not_to be_valid
+      end
+
+      it "エラーメッセージが設定される" do
+        kpt.valid?
+        expect(kpt.errors[:try]).to include("を入力してください")
+      end
+    end
+  end
+end

--- a/backend/spec/models/kpt_spec.rb
+++ b/backend/spec/models/kpt_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe Kpt, type: :model do
     end
 
     it "正常に保存できる" do
-      expect{kpt.save}.to change(Kpt, :count).by(1)
+      expect { kpt.save }.to change { Kpt.count }.by(1)
     end
   end
 
   context "userがnilの場合" do
     let(:kpt) { build(:kpt, user: nil) }
-  
+
     it "バリデーションエラーになる" do
       expect(kpt).not_to be_valid
     end
-  
+
     it "エラーメッセージが設定される" do
       kpt.valid?
       expect(kpt.errors[:user]).to include("を入力してください")
@@ -42,11 +42,11 @@ RSpec.describe Kpt, type: :model do
 
     context "dateが重複している場合" do
       let(:user) { create(:user) }
-      let!(:existing_kpt) { create(:kpt, date: Date.today, user: user) }
-      let(:kpt) { build(:kpt, date: Date.today, user: user) }
+      let!(:existing_kpt) { create(:kpt, date: Time.zone.today, user: user) }
+      let(:kpt) { build(:kpt, date: Time.zone.today, user: user) }
 
       it "バリデーションエラーになる" do
-        expect { kpt.save }.not_to change(Kpt, :count)
+        expect { kpt.save }.not_to change { Kpt.count }
       end
 
       it "エラーメッセージが設定される" do
@@ -54,7 +54,7 @@ RSpec.describe Kpt, type: :model do
         expect(kpt.errors[:date]).to include("この日のKPTのはすでに登録されています")
       end
     end
-  
+
     context "keepがnilの場合" do
       let(:kpt) { build(:kpt, keep: nil) }
 

--- a/backend/spec/models/kpt_spec.rb
+++ b/backend/spec/models/kpt_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Kpt, type: :model do
 
       it "エラーメッセージが設定される" do
         kpt.valid?
-        expect(kpt.errors[:date]).to include("この日のKPTのはすでに登録されています")
+        expect(kpt.errors[:date]).to include("この日のKPTはすでに登録されています")
       end
     end
 

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -70,4 +70,6 @@ RSpec.configure do |config|
   
   # FactoryBot の構文メソッドを直接使用できるようにする
   config.include FactoryBot::Syntax::Methods
+  # カスタムヘルパーモジュールを読み込む
+  config.include AuthHelper, type: :request
 end

--- a/backend/spec/requests/kpts_spec.rb
+++ b/backend/spec/requests/kpts_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe "Kpts", type: :request do
+  let(:user) { create(:user) }
+  
+  describe "POST /api/v1/kpts" do
+    context "認証情報がヘッダーに記載された場合" do
+      let(:headers) { login_user(user) }
+
+      context "正しいパラメータを送信した場合" do
+        let(:kpt_params) { attributes_for(:kpt) }
+
+        it "KPTが登録される" do
+          expect { post api_v1_kpts_path, params: { kpt: kpt_params }, headers: headers }.to change(user.kpts, :count).by(1)
+        end
+
+        it "ステータスコード201が返る" do
+          post api_v1_kpts_path, params: { kpt: kpt_params }, headers: headers
+          expect(response).to have_http_status(:created)
+        end
+
+        it "登録したKPTが返る" do
+          post api_v1_kpts_path, params: { kpt: kpt_params }, headers: headers
+          body = JSON.parse(response.body)
+          expect(body["kpt"]["keep"]).to eq(kpt_params[:keep])
+          expect(body["kpt"]["problem"]).to eq(kpt_params[:problem])
+          expect(body["kpt"]["try"]).to eq(kpt_params[:try])
+        end
+      end
+
+      context "不正なパラメータを送信した場合" do
+        let(:invalid_kpt_params) { attributes_for(:kpt, keep: nil) }
+
+        it "KPTが登録されない" do
+          expect { post api_v1_kpts_path, params: { kpt: invalid_kpt_params }, headers: headers}.to change(user.kpts, :count).by(0)
+        end
+
+        it "ステータスコード422が返る" do
+          post api_v1_kpts_path, params: { kpt: invalid_kpt_params }, headers: headers
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "エラーメッセージが返る" do
+          post api_v1_kpts_path, params: { kpt: invalid_kpt_params }, headers: headers
+          body = JSON.parse(response.body)
+          expect(body["message"]).to eq("Keepを入力してください")
+        end
+      end
+
+
+    end
+
+    context "認証情報がヘッダーに記載されていない場合" do
+      let(:kpt_params) { attributes_for(:kpt) }
+
+      it "KPTが登録されない" do
+        expect { post api_v1_kpts_path, params: { kpt: kpt_params } }.to change(user.kpts, :count).by(0)
+      end
+
+      it "ステータスコード401が返る" do
+        post api_v1_kpts_path, params: { kpt: kpt_params }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/kpts_spec.rb
+++ b/backend/spec/requests/kpts_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Kpts", type: :request do
   let(:user) { create(:user) }
-  
+
   describe "POST /api/v1/kpts" do
     context "認証情報がヘッダーに記載された場合" do
       let(:headers) { login_user(user) }
@@ -11,7 +11,7 @@ RSpec.describe "Kpts", type: :request do
         let(:kpt_params) { attributes_for(:kpt) }
 
         it "KPTが登録される" do
-          expect { post api_v1_kpts_path, params: { kpt: kpt_params }, headers: headers }.to change(user.kpts, :count).by(1)
+          expect { post api_v1_kpts_path, params: { kpt: kpt_params }, headers: headers }.to change { user.kpts.count }.by(1)
         end
 
         it "ステータスコード201が返る" do
@@ -21,7 +21,7 @@ RSpec.describe "Kpts", type: :request do
 
         it "登録したKPTが返る" do
           post api_v1_kpts_path, params: { kpt: kpt_params }, headers: headers
-          body = JSON.parse(response.body)
+          body = response.parsed_body
           expect(body["kpt"]["keep"]).to eq(kpt_params[:keep])
           expect(body["kpt"]["problem"]).to eq(kpt_params[:problem])
           expect(body["kpt"]["try"]).to eq(kpt_params[:try])
@@ -32,7 +32,7 @@ RSpec.describe "Kpts", type: :request do
         let(:invalid_kpt_params) { attributes_for(:kpt, keep: nil) }
 
         it "KPTが登録されない" do
-          expect { post api_v1_kpts_path, params: { kpt: invalid_kpt_params }, headers: headers}.to change(user.kpts, :count).by(0)
+          expect { post api_v1_kpts_path, params: { kpt: invalid_kpt_params }, headers: headers }.not_to change { user.kpts.count }
         end
 
         it "ステータスコード422が返る" do
@@ -42,19 +42,17 @@ RSpec.describe "Kpts", type: :request do
 
         it "エラーメッセージが返る" do
           post api_v1_kpts_path, params: { kpt: invalid_kpt_params }, headers: headers
-          body = JSON.parse(response.body)
+          body = response.parsed_body
           expect(body["message"]).to eq("Keepを入力してください")
         end
       end
-
-
     end
 
     context "認証情報がヘッダーに記載されていない場合" do
       let(:kpt_params) { attributes_for(:kpt) }
 
       it "KPTが登録されない" do
-        expect { post api_v1_kpts_path, params: { kpt: kpt_params } }.to change(user.kpts, :count).by(0)
+        expect { post api_v1_kpts_path, params: { kpt: kpt_params } }.not_to change { user.kpts.count }
       end
 
       it "ステータスコード401が返る" do

--- a/backend/spec/support/auth_helper.rb
+++ b/backend/spec/support/auth_helper.rb
@@ -1,6 +1,6 @@
 module AuthHelper
   def login_user(user)
-    post '/api/v1/auth/sign_in', params: {email: user.email, password: user.password}
-    response.headers.slice('client', 'access-token', 'uid')
+    post "/api/v1/auth/sign_in", params: { email: user.email, password: user.password }
+    response.headers.slice("client", "access-token", "uid")
   end
 end

--- a/backend/spec/support/auth_helper.rb
+++ b/backend/spec/support/auth_helper.rb
@@ -1,0 +1,6 @@
+module AuthHelper
+  def login_user(user)
+    post '/api/v1/auth/sign_in', params: {email: user.email, password: user.password}
+    response.headers.slice('client', 'access-token', 'uid')
+  end
+end

--- a/frontend/src/pages/create_kpt.tsx
+++ b/frontend/src/pages/create_kpt.tsx
@@ -1,0 +1,140 @@
+import {
+  Box,
+  Container,
+  Typography,
+  Stack,
+  TextField,
+  Button,
+} from '@mui/material'
+import axios, { AxiosResponse, AxiosError } from 'axios'
+import { NextPage } from 'next'
+import { useForm, SubmitHandler, Controller } from 'react-hook-form'
+
+type CreateKptFormData = {
+  date: string
+  keep: string
+  problem: string
+  try: string
+}
+
+const CreateKpt: NextPage = () => {
+  const { handleSubmit, control } = useForm<CreateKptFormData>({
+    defaultValues: {
+      date: new Date().toISOString().split('T')[0],
+      keep: '',
+      problem: '',
+      try: '',
+    },
+  })
+
+  const validationRules = {
+    date: {
+      required: '日付は必須です',
+    },
+    keep: {
+      required: 'KEEPを入力してください',
+    },
+    problem: {
+      required: 'PROBLEMを入力してください',
+    },
+    try: {
+      required: 'TRYを入力してください',
+    },
+  }
+
+  const onSubmit: SubmitHandler<CreateKptFormData> = (data) => {
+    const url = process.env.NEXT_PUBLIC_API_BASE_URL + '/kpts'
+    const headers = {
+      'Content-Type': 'application/json',
+      'access-token': localStorage.getItem('access-token'),
+      client: localStorage.getItem('client'),
+      uid: localStorage.getItem('uid'),
+    }
+    const requestData = {
+      kpt: data,
+    }
+
+    axios({ method: 'POST', url: url, headers: headers, data: requestData })
+      .then((res: AxiosResponse) => {
+        console.log(res.data)
+      })
+      .catch((error: AxiosError) => {
+        console.log(error.message)
+      })
+  }
+
+  return (
+    <Box>
+      <Container maxWidth="sm">
+        <Box>
+          <Typography component="h2" sx={{ fontSize: 32, fontWeight: 'bold' }}>
+            Create
+          </Typography>
+        </Box>
+        <Stack component="form" onSubmit={handleSubmit(onSubmit)} spacing={2}>
+          <Controller
+            name="date"
+            control={control}
+            rules={validationRules.date}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="date"
+                label="日付"
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="keep"
+            control={control}
+            rules={validationRules.keep}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="KEEP"
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="problem"
+            control={control}
+            rules={validationRules.problem}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="PROBLEM"
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="try"
+            control={control}
+            rules={validationRules.try}
+            render={({ field, fieldState }) => (
+              <TextField
+                {...field}
+                type="text"
+                label="TRY"
+                error={fieldState.invalid}
+                helperText={fieldState.error?.message}
+              />
+            )}
+          />
+          <Button variant="contained" type="submit">
+            作成
+          </Button>
+        </Stack>
+      </Container>
+    </Box>
+  )
+}
+
+export default CreateKpt


### PR DESCRIPTION
## 変更の概要

* KPTの新規投稿機能を実装しました
* バックエンドAPIとフロントエンドの画面を作成しました

## なぜこの変更をするのか

* ユーザーが日々のKPT（Keep, Problem, Try）を記録できるようにするため
* 日付、Keep、Problem、Try の情報を保存し、後で振り返られるようにするため

## 変更内容

* バックエンド:
  - KPTモデルの作成と関連するバリデーション
  - KPTコントローラーの作成（createアクション）
  - テストコードの実装（モデル、リクエスト）
  - 日本語化対応

* フロントエンド:
  - KPT新規作成画面の実装
  - API連携処理の実装
  - フォームバリデーションの実装

## 影響範囲

* ユーザーに影響すること
  - ユーザーはWebアプリからKPTを記録できるようになります

* システムに影響すること
  - KPTテーブルが新たに作成されます
  - KPTデータが増えるにつれてDBの容量が増加します

## どうやるのか

* ログイン後、Create KPT画面にアクセスします
* 日付、Keep、Problem、Tryを入力して作成ボタンを押します
* 一人のユーザーは同じ日付のKPTを1つだけ登録できます（重複不可）

## 課題

* エラーメッセージの表示について、フロントエンド側の実装がまだ不十分です
* 成功時のリダイレクト処理が未実装です
* KPT一覧表示機能が未実装です

## 備考

* 今後の予定として、KPTの一覧表示と編集・削除機能を追加する予定です
* モバイル対応はまだ十分ではないため、次のリリースで対応予定です
